### PR TITLE
<Fix>修复读取空文件时无法分割导致数组越界无法正常初始化的问题 (BuffPlugin.cs Line 313)

### DIFF
--- a/RandomBuff/BuffPlugin.cs
+++ b/RandomBuff/BuffPlugin.cs
@@ -310,8 +310,7 @@ namespace RandomBuff
             {
                 bool hasDeleteAll = false;
                 var lines = File.ReadAllLines(Path.Combine(CacheFolder, "buffVersion")).ToList();
-                var lastVersion = lines.ToDictionary(i => i.Split('|')[0], i => i.Split('|')[1]);
-
+                var lastVersion = (lines == null || lines.Count == 0) ? [] : lines.ToDictionary(i => i.Split('|')[0], i => i.Split('|')[1]);    //修复读取空文件时无法分割导致数组越界无法正常初始化的问题
                 foreach (var mod in ModManager.ActiveMods.Where(i =>
                              Directory.Exists(Path.Combine(i.basePath, "buffplugins")) ||
                              Directory.Exists(Path.Combine(i.basePath, "buffassets"))))


### PR DESCRIPTION
在游玩时的某次重启后RandomBuff的卡牌按钮未正常显示，使用BepInEx控制台发现数组越界且无“!!!!TEST BUILD!!!!”的输出，于是锁定问题于CheckBuffPluginVersion()函数，在313行发现问题，即读取空文件时无法正常分割字符串。
![235a3e4c62878de76ce7c5457465ee0c](https://github.com/user-attachments/assets/841c5979-6368-4c45-8eec-182db33581c7)
![f88386623d922891e6291b2c81cae109](https://github.com/user-attachments/assets/c36e8201-c041-413d-b150-001ff6bd370a)
