### PR TITLE
Fixes for bugs related to the toggling of FireShield, FlashShield, and SporePuffCrestBuff

### DIFF
--- a/BuildInBuff/Positive/FireShieldBuff.cs
+++ b/BuildInBuff/Positive/FireShieldBuff.cs
@@ -49,6 +49,21 @@ namespace BuiltinBuffs.Positive
                 }
             }
         }
+
+        public override bool Trigger(RainWorldGame game)
+        {
+            bool? state = null;
+            foreach (var player in FireShieldBuffEntry.PlayerList)
+            {
+                if (!FireShieldBuffEntry.FireShieldStateFeatures.TryGetValue(player, out var fireShieldState)) continue;
+                if (state is null) state = fireShieldState.IsActivate;
+                if (state.Value)
+                    fireShieldState.Deactivate();
+                else
+                    fireShieldState.Activate();
+            }
+            return false;
+        }
     }
 
     internal class FireShieldBuffData : BuffData
@@ -282,18 +297,6 @@ namespace BuiltinBuffs.Positive
 
         public void Update()
         {
-            foreach (var player in FireShieldBuffEntry.PlayerList)
-            {
-                if (FireShieldBuffEntry.FireShieldStateFeatures.TryGetValue(player, out var fireShield) &&
-                    BuffInput.GetKeyDown(FireShieldBuff.Instance.GetBindKey()))
-                {
-                    FireShieldBuff.Instance.TriggerSelf(true);
-                    if (fireShield.IsActivate)
-                        fireShield.Deactivate();
-                    else if (!fireShield.IsActivate)
-                        fireShield.Activate();
-                }
-            }
         }
 
         public void Activate()

--- a/BuildInBuff/Positive/FlashShieldBuff.cs
+++ b/BuildInBuff/Positive/FlashShieldBuff.cs
@@ -49,6 +49,21 @@ namespace BuiltinBuffs.Positive
                 }
             }
         }
+        
+        public override bool Trigger(RainWorldGame game)
+        {
+            bool? state = null;
+            foreach (var player in FlashShieldBuffEntry.PlayerList)
+            {
+                if (!FlashShieldBuffEntry.FlashShieldStateFeatures.TryGetValue(player, out var flashShield)) continue;
+                if (state is null) state = flashShield.IsActivate;
+                if (state.Value) 
+                    flashShield.Deactivate();
+                else 
+                    flashShield.Activate();
+            }
+            return false;
+        }
     }
 
     internal class FlashShieldBuffData : BuffData
@@ -563,18 +578,6 @@ namespace BuiltinBuffs.Positive
 
         public void Update()
         {
-            foreach (var player in FlashShieldBuffEntry.PlayerList)
-            {
-                if (FlashShieldBuffEntry.FlashShieldStateFeatures.TryGetValue(player, out var flashShield) &&
-                    BuffInput.GetKeyDown(FlashShieldBuff.Instance.GetBindKey()))
-                {
-                    FlashShieldBuff.Instance.TriggerSelf(true);
-                    if (flashShield.IsActivate)
-                        flashShield.Deactivate();
-                    else if (!flashShield.IsActivate)
-                        flashShield.Activate();
-                }
-            }
         }
 
         public void Activate()

--- a/BuildInBuff/Positive/SporePuff'sCrestBuff.cs
+++ b/BuildInBuff/Positive/SporePuff'sCrestBuff.cs
@@ -51,16 +51,15 @@ namespace BuiltinBuffs.Positive
 
         public override bool Trigger(RainWorldGame game)
         {
+            bool? state = null;
             foreach (var player in SporePuff_sCrestBuffEntry.PlayerList)
             {
-                if (SporePuff_sCrestBuffEntry.SporePuff_sCrestStateFeatures.TryGetValue(player, out var sporePuff_sCrest) &&
-                    BuffInput.GetKeyDown(GetBindKey()))
-                {
-                    if (sporePuff_sCrest.IsActivate)
-                        sporePuff_sCrest.Deactivate();
-                    else if (!sporePuff_sCrest.IsActivate)
-                        sporePuff_sCrest.Activate();
-                }
+                if (!SporePuff_sCrestBuffEntry.SporePuff_sCrestStateFeatures.TryGetValue(player, out var sporePuff_sCrest)) continue;
+                if (state is null) state = sporePuff_sCrest.IsActivate;
+                if (state.Value) 
+                    sporePuff_sCrest.Deactivate();
+                else 
+                    sporePuff_sCrest.Activate();
             }
             return false;
         }

--- a/RandomBuff/Render/UI/CardInteractionManager.cs
+++ b/RandomBuff/Render/UI/CardInteractionManager.cs
@@ -656,7 +656,7 @@ namespace RandomBuff.Render.UI
         public class KeyBinderProcessor
         {
             public List<BuffID> triggerableBuffIDs = new List<BuffID>();
-            Dictionary<BuffID, bool>lastKeyDowns = new Dictionary<BuffID, bool>();
+            static Dictionary<BuffID, bool>lastKeyDowns = new Dictionary<BuffID, bool>();
 
             InGameSlotInteractionManager manager;
 
@@ -676,7 +676,7 @@ namespace RandomBuff.Render.UI
                 if(card.StaticData.Triggerable)
                 {
                     triggerableBuffIDs.Add(card.ID);
-                    lastKeyDowns.Add(card.ID, false);
+                    lastKeyDowns[card.ID] = false;
                 }
             }
 


### PR DESCRIPTION
Fix inconsistencies with disabling / enabling of FireShield, FlashShield, and SporePuffCrestBuff in single player
Fix the above three not toggling on or off at all in jolly co-op